### PR TITLE
Add text nodes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ gemfile:
   - gemfiles/activesupport-3.2
   - gemfiles/activesupport-4.0
   - gemfiles/activesupport-4.2
+sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in xml-section.gemspec
 gemspec
 
-gem "pry-byebug", "~> 1.3.3", platform: [:mri_20, :mri_21]
+gem "pry-byebug", "~> 2.0.0", platform: [:mri_20, :mri_21]
 gem "pry-debugger", "~> 0.2.3", platform: :mri_19
 gem "pry-doc", "~> 0.6.0"
 gem "bond", "~> 0.5.1"

--- a/lib/hermod.rb
+++ b/lib/hermod.rb
@@ -1,4 +1,5 @@
 require 'hermod/xml_section'
+require 'hermod/version'
 
 I18n.enforce_available_locales = false
 

--- a/lib/hermod/newline_replacer.rb
+++ b/lib/hermod/newline_replacer.rb
@@ -1,0 +1,27 @@
+require 'pry'
+
+module Hermod
+  class NewlineReplacer
+    attr_reader :replacement
+
+    DEFAULT_REPLACEMENT = "  "
+
+    # Public: sets up the mutator with the replacement character. By default
+    # two spaces are used.
+    def initialize(repl = DEFAULT_REPLACEMENT)
+      @replacement = (repl.is_a?(String) ? repl : DEFAULT_REPLACEMENT)
+    end
+
+    # Public: changes the value passed in so all newlines are replaced with the
+    # replacement character set up when this was initialised (or two spaces if
+    # no replacement was provided). Attributes remain unchanged.
+    #
+    # value - the value of the XML node
+    # attributes - the attributes of the XML node as a Hash
+    #
+    # Returns the new value and attributes as an Array.
+    def mutate!(value, attributes)
+      [value.gsub(/[\n\r]/, replacement), attributes]
+    end
+  end
+end

--- a/lib/hermod/newline_replacer.rb
+++ b/lib/hermod/newline_replacer.rb
@@ -18,7 +18,7 @@ module Hermod
     # attributes - the attributes of the XML node as a Hash
     #
     # Returns the new value and attributes as an Array.
-    def mutate!(value, attributes)
+    def mutate!(value, attributes, instance)
       [value.gsub(/[\n\r]/, replacement), attributes]
     end
   end

--- a/lib/hermod/newline_replacer.rb
+++ b/lib/hermod/newline_replacer.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 module Hermod
   class NewlineReplacer
     attr_reader :replacement

--- a/spec/hermod/xml_section_builder/text_node_spec.rb
+++ b/spec/hermod/xml_section_builder/text_node_spec.rb
@@ -1,0 +1,86 @@
+require "minitest_helper"
+
+module Hermod
+  describe XmlSection do
+
+    TextXml = XmlSection.build do |builder|
+      builder.text_node :greeting
+      builder.text_node :name, optional: true
+      builder.text_node :title, matches: /\ASir|Dame\z/, attributes: {masculine: "Male"}
+      builder.text_node :required
+      builder.text_node :gender, input_mutator: (lambda do |value, attributes|
+        [value == "Male" ? "M" : "F", attributes]
+      end)
+      builder.text_node :mood, allowed_values: %w(Happy Sad Hangry)
+      builder.text_node :biography, replace_newlines: true
+      builder.text_node :telegram, replace_newlines: " STOP "
+    end
+
+    describe "Text nodes" do
+      subject do
+        TextXml.new do |text_xml|
+          text_xml.greeting "Hello"
+        end
+      end
+
+      it "should set node contents correctly" do
+        value_of_node("Greeting").must_equal "Hello"
+      end
+
+      it "should allow values that pass the regex validation" do
+        subject.title "Sir"
+        value_of_node("Title").must_equal "Sir"
+      end
+
+      it "should raise an error when the regex validation fails" do
+        ex = proc { subject.title "Laird" }.must_raise InvalidInputError
+        ex.message.must_equal %(title "Laird" does not match /\\ASir|Dame\\z/)
+      end
+
+      it "should require all non-optional nodes to have content" do
+        ex = proc { subject.required "" }.must_raise InvalidInputError
+        ex.message.must_equal "required isn't optional but no value was provided"
+      end
+
+      it "should apply changes to the inputs if a input_mutator is provided" do
+        subject.gender "Male"
+        value_of_node("Gender").must_equal "M"
+      end
+
+      it "should restrict values to those in the list of allowed values if such a list is provided" do
+        subject.mood "Hangry"
+        value_of_node("Mood").must_equal "Hangry"
+      end
+
+      it "should raise an error if the value is not in the list of allowed values" do
+        ex = proc { subject.mood "Jubilant" }.must_raise InvalidInputError
+        ex.message.must_equal "mood must be one of Happy, Sad, or Hangry, not Jubilant"
+      end
+
+      it "should use the given keys for attributes" do
+        subject.title "Sir", masculine: "no"
+        attributes_for_node("Title").keys.first.must_equal "Male"
+        attributes_for_node("Title")["Male"].value.must_equal "no"
+      end
+
+      it "should raise an error if given an attribute that isn't expected" do
+        proc { subject.title "Sir", knight: "yes" }.must_raise InvalidInputError
+      end
+
+      it "should not include empty, optional nodes" do
+        subject.name ""
+        nodes("Name").must_be_empty
+      end
+
+      it "should replace newlines with two spaces if replace_newlines is truthy and not a string" do
+        subject.biography "I'm\na\nvery\nboring\nperson"
+        value_of_node("Biography").must_equal "I'm  a  very  boring  person"
+      end
+
+      it "should replace newlines with the given text if replace_newlines is truthy and a string" do
+        subject.telegram "Urgent\nEnemy troops en-route\nAttack at dawn\n"
+        value_of_node("Telegram").must_equal "Urgent STOP Enemy troops en-route STOP Attack at dawn STOP "
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds support for text nodes with the ability to replace newlines with something else (two spaces by default). String nodes haven't changed so could still have linebreaks in but I'd suggest we remove this ability in future.
