### PR TITLE
Allow zero monetary nodes that aren't excluded

### DIFF
--- a/lib/hermod/xml_section_builder.rb
+++ b/lib/hermod/xml_section_builder.rb
@@ -147,8 +147,8 @@ module Hermod
     def monetary_node(name, options={})
       validators = [].tap do |validators|
         validators << Validators::NonNegative.new unless options.fetch(:negative, true)
+        validators << Validators::NonZero.new unless options.fetch(:zero, true)
         validators << Validators::WholeUnits.new if options[:whole_units]
-        validators << Validators::NonZero.new unless options[:optional]
       end
 
       create_method(name, [], validators, options) do |value, attributes|

--- a/spec/hermod/xml_section_builder/monetary_node_spec.rb
+++ b/spec/hermod/xml_section_builder/monetary_node_spec.rb
@@ -8,6 +8,7 @@ module Hermod
       builder.monetary_node :tax, optional: true
       builder.monetary_node :ni, xml_name: "NI", negative: false
       builder.monetary_node :pension, whole_units: true
+      builder.monetary_node :student_loan, zero: false, negative: false
     end
 
     describe "Monetary nodes" do
@@ -44,6 +45,11 @@ module Hermod
       it "should not allow decimal values for whole unit nodes" do
         ex = proc { subject.pension BigDecimal.new("12.34") }.must_raise InvalidInputError
         ex.message.must_equal "pension must be in whole units"
+      end
+
+      it "should not allow zero for nodes that disallow it" do
+        ex = proc { subject.student_loan 0 }.must_raise Hermod::InvalidInputError
+        ex.message.must_equal "student_loan cannot be zero"
       end
     end
   end


### PR DESCRIPTION
Optional monetary nodes are excluded from the XML if they're zero. Other nodes
can be zero and should be included. Currently we validate against this which is
incorrect.

Increments the patch version accordingly.
