### PR TITLE
Don't require blanks to match

### DIFF
--- a/lib/hermod/validators/regular_expression.rb
+++ b/lib/hermod/validators/regular_expression.rb
@@ -13,8 +13,12 @@ module Hermod
 
       private
 
+      # Public: Checks the value matches the pattern. Blank values are ignored
+      # because those are checked by the ValuePresence validator if necessary.
+      #
+      # Returns a boolean
       def test
-        value =~ pattern
+        value.blank? || value =~ pattern
       end
 
       def message

--- a/lib/hermod/version.rb
+++ b/lib/hermod/version.rb
@@ -1,3 +1,3 @@
 module Hermod
-  VERSION = "1.2.0"
+  VERSION = "1.2.2"
 end

--- a/spec/hermod/validators/regular_expression_spec.rb
+++ b/spec/hermod/validators/regular_expression_spec.rb
@@ -11,6 +11,11 @@ module Hermod
         subject.valid?("AB123456C", {}).must_equal true
       end
 
+      it "allows blank values" do
+        subject.valid?("", {}).must_equal true
+        subject.valid?(nil, {}).must_equal true
+      end
+
       it "raises an error for values that don't match the pattern" do
         ex = proc { subject.valid?("fish", {}) }.must_raise InvalidInputError
         ex.message.must_equal "\"fish\" does not match /\\A[A-Z]{2} [0-9]{6} [A-D]\\z/x"


### PR DESCRIPTION
Blank values shouldn't fail when testing against a regular expression matcher,
instead they should be caught by the value presence validator if necessary.

This allows optional nodes with a regular expression constraint.
