### PR TITLE
Allowed Values only apply if value is present

### DIFF
--- a/lib/hermod/validators/allowed_values.rb
+++ b/lib/hermod/validators/allowed_values.rb
@@ -19,7 +19,7 @@ module Hermod
 
       def message
         list_of_values = allowed_values.to_sentence(last_word_connector: ", or ", two_words_connector: " or ")
-        "must be one of #{list_of_values}, not #{value.inspect}"
+        "must be one of #{list_of_values}, not #{value}"
       end
     end
   end

--- a/spec/hermod/validators/allowed_values_spec.rb
+++ b/spec/hermod/validators/allowed_values_spec.rb
@@ -18,7 +18,7 @@ module Hermod
 
       it "raises an error for values not in the list" do
         ex = proc { subject.valid?("Albatross", {}) }.must_raise InvalidInputError
-        ex.message.must_equal %{must be one of Antelope, Bear, Cat, Dog, or Elephant, not "Albatross"}
+        ex.message.must_equal "must be one of Antelope, Bear, Cat, Dog, or Elephant, not Albatross"
       end
     end
   end

--- a/spec/hermod/xml_section_builder/string_node_spec.rb
+++ b/spec/hermod/xml_section_builder/string_node_spec.rb
@@ -52,7 +52,7 @@ module Hermod
 
       it "should raise an error if the value is not in the list of allowed values" do
         ex = proc { subject.mood "Jubilant" }.must_raise InvalidInputError
-        ex.message.must_equal %{mood must be one of Happy, Sad, or Hangry, not "Jubilant"}
+        ex.message.must_equal "mood must be one of Happy, Sad, or Hangry, not Jubilant"
       end
 
       it "should use the given keys for attributes" do


### PR DESCRIPTION
We don't need to check blanks are in the list because we have the value presence validator for that instead.
