### PR TITLE
Validators all allow blanks except ValuePresence

### DIFF
--- a/lib/hermod/validators/non_negative.rb
+++ b/lib/hermod/validators/non_negative.rb
@@ -8,7 +8,7 @@ module Hermod
       private
 
       def test
-        value >= 0
+        value.blank? || value >= 0
       end
 
       def message

--- a/lib/hermod/validators/non_zero.rb
+++ b/lib/hermod/validators/non_zero.rb
@@ -8,7 +8,7 @@ module Hermod
       private
 
       def test
-        value.to_i != 0
+        value.blank? || value.to_i != 0
       end
 
       def message

--- a/lib/hermod/validators/range.rb
+++ b/lib/hermod/validators/range.rb
@@ -17,7 +17,7 @@ module Hermod
       private
 
       def test
-        range.cover?(value)
+        value.blank? || range.cover?(value)
       end
 
       def message

--- a/lib/hermod/validators/whole_units.rb
+++ b/lib/hermod/validators/whole_units.rb
@@ -9,7 +9,7 @@ module Hermod
       private
 
       def test
-        value == value.to_i
+        value.blank? || value == value.to_i
       end
 
       def message

--- a/spec/hermod/validators/non_negative_spec.rb
+++ b/spec/hermod/validators/non_negative_spec.rb
@@ -15,6 +15,10 @@ module Hermod
         subject.valid?(0, {}).must_equal true
       end
 
+      it "allows blank values" do
+        subject.valid?(nil, {}).must_equal true
+      end
+
       it "raises an error for negative values" do
         ex = proc { subject.valid?(-1, {}) }.must_raise InvalidInputError
         ex.message.must_equal "cannot be negative"

--- a/spec/hermod/validators/non_zero_spec.rb
+++ b/spec/hermod/validators/non_zero_spec.rb
@@ -15,6 +15,10 @@ module Hermod
         subject.valid?(-1, {}).must_equal true
       end
 
+      it "allows blank values" do
+        subject.valid?(nil, {}).must_equal true
+      end
+
       it "raises an error for zero values" do
         ex = proc { subject.valid?(0, {}) }.must_raise InvalidInputError
         ex.message.must_equal "cannot be zero"

--- a/spec/hermod/validators/range_spec.rb
+++ b/spec/hermod/validators/range_spec.rb
@@ -12,6 +12,10 @@ module Hermod
         subject.valid?(7, {}).must_equal true
       end
 
+      it "allows blank values" do
+        subject.valid?(nil, {}).must_equal true
+      end
+
       it "raises an error for values outwith the range" do
         ex = proc { subject.valid?(0, {}) }.must_raise InvalidInputError
         ex.message.must_equal "must be between 1 and 7"

--- a/spec/hermod/validators/whole_units_spec.rb
+++ b/spec/hermod/validators/whole_units_spec.rb
@@ -11,6 +11,10 @@ module Hermod
         subject.valid?(1.0, {}).must_equal true
       end
 
+      it "allows blank values" do
+        subject.valid?(nil, {}).must_equal true
+      end
+
       it "raises an error for values with a fractional componant" do
         ex = proc { subject.valid?(3.1415, {}) }.must_raise InvalidInputError
         ex.message.must_equal "must be in whole units"


### PR DESCRIPTION
The value presence validator checks if something is present. All the other
validators should just ignore blank values and let them fall through. If it's
an error the value presence validator will catch them and if it's not the XML
generated won't include that node because it's blank.
