### PR TITLE
Monetary nodes should ignore nil values

### DIFF
--- a/lib/hermod/xml_section_builder.rb
+++ b/lib/hermod/xml_section_builder.rb
@@ -152,7 +152,8 @@ module Hermod
       end
 
       create_method(name, [], validators, options) do |value, attributes|
-        if (options[:optional] && value == 0) || value.blank?
+        value = value.to_i
+        if options[:optional] && value == 0
           [nil, attributes]
         else
           [sprintf(format_for(:money), value), attributes]

--- a/spec/hermod/xml_section_builder/monetary_node_spec.rb
+++ b/spec/hermod/xml_section_builder/monetary_node_spec.rb
@@ -52,9 +52,12 @@ module Hermod
         ex.message.must_equal "student_loan cannot be zero"
       end
 
-      it "should ignore blank nodes" do
+      it "should treat blank nodes as zero nodes" do
         subject.ni nil
-        nodes("NI").must_be_empty
+        value_of_node("NI").must_equal "0.00"
+
+        subject.tax nil
+        nodes("Tax").must_be_empty
       end
     end
   end


### PR DESCRIPTION
All the other nodes accept nil values and pass them through. Monetary nodes
were choking when trying to sprintf a nil. This fixes that.
