### PR TITLE
Fix activesupport and minitest reporters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ gem "pry-byebug", "~> 1.3.3", platform: [:mri_20, :mri_21]
 gem "pry-debugger", "~> 0.2.3", platform: :mri_19
 gem "pry-doc", "~> 0.6.0"
 gem "bond", "~> 0.5.1"
+
+gem "minitest-reporters", github: "Haegin/minitest-reporters", branch: "fix-activesupport-fix"

--- a/hermod.gemspec
+++ b/hermod.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.3"
   spec.add_development_dependency "minitest", "~> 5.3"
   spec.add_development_dependency "minitest-reporters", "~> 1.0"
+  spec.add_development_dependency "activesupport", "> 4.2", "< 5"
   spec.add_development_dependency "guard", "~> 2.6.1"
   spec.add_development_dependency "guard-minitest", "~> 2.3.1"
   spec.add_development_dependency "nokogiri", "~> 1.5"

--- a/spec/minitest_helper.rb
+++ b/spec/minitest_helper.rb
@@ -1,5 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'hermod'
+require "hermod"
 
 require "minitest/autorun"
 require "minitest/hell"


### PR DESCRIPTION
This fixes a bug that occurs when using minitest_reporters with
activesupport >= 3.2.18, < 4. When (if) the bugfix is merged we remove this.