### PR TITLE
Mutators can access the node they're mutating values for

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-bundler_args: --without debugging local_testing
+bundler_args: --without test
 rvm:
   - 2.1.6
   - 2.2.2

--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,11 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in xml-section.gemspec
 gemspec
 
-group :debugging do
+group :test do
+  gem "guard", "~> 2.6.1"
+  gem "guard-minitest", "~> 2.3.1"
   gem "pry-byebug", "~> 1.3.3", platform: [:mri_20, :mri_21]
   gem "pry-debugger", "~> 0.2.3", platform: :mri_19
   gem "pry-doc", "~> 0.6.0"
   gem "bond", "~> 0.5.1"
-end
-
-group :local_testing do
-  gem "guard", "~> 2.6.1"
-  gem "guard-minitest", "~> 2.3.1"
 end

--- a/lib/hermod/input_mutator.rb
+++ b/lib/hermod/input_mutator.rb
@@ -7,7 +7,11 @@ module Hermod
     end
 
     def mutate!(values, attributes, instance)
-      mutator_proc.call(values, attributes, instance)
+      if mutator_proc.arity == 2
+        mutator_proc.call(values, attributes)
+      else
+        mutator_proc.call(values, attributes, instance)
+      end
     end
   end
 end

--- a/lib/hermod/input_mutator.rb
+++ b/lib/hermod/input_mutator.rb
@@ -6,8 +6,8 @@ module Hermod
       @mutator_proc = mutator_proc
     end
 
-    def mutate!(values, attributes)
-      mutator_proc.call(values, attributes)
+    def mutate!(values, attributes, instance)
+      mutator_proc.call(values, attributes, instance)
     end
   end
 end

--- a/lib/hermod/xml_section_builder.rb
+++ b/lib/hermod/xml_section_builder.rb
@@ -192,7 +192,7 @@ module Hermod
       xml_name = options.fetch(:xml_name, name.to_s.camelize)
 
       @new_class.send :define_method, name do |value, attributes = {}|
-        mutators.each { |mutator| value, attributes = mutator.mutate!(value, attributes) }
+        mutators.each { |mutator| value, attributes = mutator.mutate!(value, attributes, self) }
         begin
           validators.each { |validator| validator.valid?(value, attributes) }
         rescue InvalidInputError => ex

--- a/spec/hermod/xml_section_builder/string_node_spec.rb
+++ b/spec/hermod/xml_section_builder/string_node_spec.rb
@@ -8,10 +8,10 @@ module Hermod
       builder.string_node :name, optional: true
       builder.string_node :title, matches: /\ASir|Dame\z/, attributes: {masculine: "Male"}
       builder.string_node :required
-      builder.string_node :gender, input_mutator: (proc do |value, attributes|
+      builder.string_node :gender, input_mutator: (lambda do |value, attributes|
         [value == "Male" ? "M" : "F", attributes]
       end)
-      builder.string_node :status, input_mutator: (proc do |value, attributes, instance|
+      builder.string_node :status, input_mutator: (lambda do |value, attributes, instance|
         adjective = case instance.nodes[:mood].first.value
         when "Happy"
           "joyously"

--- a/spec/hermod/xml_section_builder/string_node_spec.rb
+++ b/spec/hermod/xml_section_builder/string_node_spec.rb
@@ -8,8 +8,19 @@ module Hermod
       builder.string_node :name, optional: true
       builder.string_node :title, matches: /\ASir|Dame\z/, attributes: {masculine: "Male"}
       builder.string_node :required
-      builder.string_node :gender, input_mutator: (lambda do |value, attributes|
+      builder.string_node :gender, input_mutator: (proc do |value, attributes|
         [value == "Male" ? "M" : "F", attributes]
+      end)
+      builder.string_node :status, input_mutator: (proc do |value, attributes, instance|
+        adjective = case instance.nodes[:mood].first.value
+        when "Happy"
+          "joyously"
+        when "Sad"
+          "dejectedly"
+        when "Hangry"
+          "furiously"
+        end
+        ["#{value} #{adjective}", attributes]
       end)
       builder.string_node :mood, allowed_values: %w(Happy Sad Hangry)
     end
@@ -43,6 +54,12 @@ module Hermod
       it "should apply changes to the inputs if a input_mutator is provided" do
         subject.gender "Male"
         value_of_node("Gender").must_equal "M"
+      end
+
+      it "should allow input_mutators to access nodes the instance" do
+        subject.mood "Hangry"
+        subject.status "Eating cookies"
+        value_of_node("Status").must_equal "Eating cookies furiously"
       end
 
       it "should restrict values to those in the list of allowed values if such a list is provided" do


### PR DESCRIPTION
This makes it possible for mutators to look at other values already set on the
instance. Instance_mutators that don't need this can use a proc to maintain the
old behaviour of just using the value and any attributes. Because people may
have been using lambdas this is still a breaking change, but this makes the
upgrade less painful than it would be.