### PR TITLE
Update dev dependencies to latest versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,10 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem "guard", "~> 2.6.1"
-  gem "guard-minitest", "~> 2.3.1"
-  gem "pry-byebug", "~> 1.3.3", platform: [:mri_20, :mri_21]
+  gem "guard", "~> 2.13.0"
+  gem "guard-minitest", "~> 2.4.4"
+  gem "pry-byebug", "~> 3.3.0", platform: [:mri_20, :mri_21]
   gem "pry-debugger", "~> 0.2.3", platform: :mri_19
-  gem "pry-doc", "~> 0.6.0"
+  gem "pry-doc", "~> 0.8.0"
   gem "bond", "~> 0.5.1"
 end

--- a/hermod.gemspec
+++ b/hermod.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activesupport", "> 3.2", "< 5"
 
   spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake", "~> 10.3"
+  spec.add_development_dependency "rake", "~> 11.1"
   spec.add_development_dependency "minitest", "~> 5.3"
   spec.add_development_dependency "minitest-reporters", "~> 1.0", ">= 1.0.16"
   spec.add_development_dependency "nokogiri", "~> 1.5"

--- a/lib/hermod.rb
+++ b/lib/hermod.rb
@@ -1,3 +1,4 @@
+require 'hermod/version'
 require 'hermod/xml_section'
 
 I18n.enforce_available_locales = false

--- a/lib/hermod/xml_section.rb
+++ b/lib/hermod/xml_section.rb
@@ -68,7 +68,7 @@ module Hermod
     #
     # Returns a String
     def self.xml_name
-      @xml_name || name.demodulize
+      @xml_name ||= name.demodulize
     end
 
     # Internal: provides access to the formats hash, falling back on an empty


### PR DESCRIPTION
This also fixes some warnings when running `rake`. There are still some other warnings but they arise from dependencies, not from `hermod` code. These are the same as in master.