### PR TITLE
Resolve BigDecimal deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ end
 *Using that XmlSection*
 ```ruby
 Example.new do |example|
-  example.taxable_pay BigDecimal.new("-300")
+  example.taxable_pay BigDecimal("-300")
 end
 ```
 
@@ -398,7 +398,7 @@ end
 *Using that XmlSection*
 ```ruby
 Example.new do |example|
-  example.lower_earnings_limit BigDecimal.new("153.49")
+  example.lower_earnings_limit BigDecimal("153.49")
 end
 ```
 
@@ -420,8 +420,8 @@ end
 *Using that XmlSection*
 ```ruby
 Example.new do |example|
-  example.taxable_pay BigDecimal.new("1000")
-  example.tax BigDecimal.new("0")
+  example.taxable_pay BigDecimal("1000")
+  example.tax BigDecimal("0")
 end
 ```
 

--- a/lib/hermod/xml_section_builder.rb
+++ b/lib/hermod/xml_section_builder.rb
@@ -32,7 +32,7 @@ module Hermod
   # defining nodes on that subclass of varying types used by HMRC.
   class XmlSectionBuilder
 
-    ZERO = BigDecimal.new('0').freeze
+    ZERO = BigDecimal("0").freeze
     BOOLEAN_VALUES = [
       YES = "yes".freeze,
       NO  = "no".freeze,

--- a/spec/hermod/xml_section_builder/monetary_node_spec.rb
+++ b/spec/hermod/xml_section_builder/monetary_node_spec.rb
@@ -43,7 +43,7 @@ module Hermod
       end
 
       it "should not allow decimal values for whole unit nodes" do
-        ex = proc { subject.pension BigDecimal.new("12.34") }.must_raise InvalidInputError
+        ex = proc { subject.pension BigDecimal("12.34") }.must_raise InvalidInputError
         ex.message.must_equal "pension must be in whole units"
       end
 

--- a/spec/hermod/xml_section_spec.rb
+++ b/spec/hermod/xml_section_spec.rb
@@ -39,7 +39,7 @@ module Hermod
       subject do
         FormattedXML.new do |formatted|
           formatted.birthday Date.new(1988, 8, 13)
-          formatted.allowance BigDecimal.new("20")
+          formatted.allowance BigDecimal("20")
         end
       end
 


### PR DESCRIPTION
`BigDecimal.new` is deprecated; use `Kernel#BigDecimal` instead.

Resolves #19