### PR TITLE
Make validation thread-safe, to fix flakey spec

### DIFF
--- a/lib/hermod/validators/base.rb
+++ b/lib/hermod/validators/base.rb
@@ -11,8 +11,11 @@ module Hermod
       # Raises a Hermod::InvalidInputError if the test fails
       # Returns true if it succeeds
       def valid?(value, attributes)
-        @value, @attributes = value, attributes
-        !!test || raise(InvalidInputError, message)
+        @mutex ||= Mutex.new
+        @mutex.synchronize do
+          @value, @attributes = value, attributes
+          !!test || raise(InvalidInputError, message)
+        end
       end
 
       private

--- a/spec/hermod/xml_section_builder/string_node_spec.rb
+++ b/spec/hermod/xml_section_builder/string_node_spec.rb
@@ -72,6 +72,19 @@ module Hermod
         ex.message.must_equal "mood must be one of Happy, Sad, or Hangry, not Jubilant"
       end
 
+      it "should be thread safe for validation" do
+        subject1 = StringXml.new do |string_xml|
+          string_xml.greeting "Hello"
+        end
+
+        Thread.new do
+          subject1.mood "Hangry"
+        end
+
+        ex = proc { subject.mood "Jubilant" }.must_raise InvalidInputError
+        ex.message.must_equal "mood must be one of Happy, Sad, or Hangry, not Jubilant"
+      end
+
       it "should use the given keys for attributes" do
         subject.title "Sir", masculine: "no"
         attributes_for_node("Title").keys.first.must_equal "Male"


### PR DESCRIPTION
## Synopsis

We are seeing a flakey spec failure:

```
Hermod::XmlSection::String nodes#test_0002_should raise an error if the value is not in the list of allowed values 
Hermod::XmlSection::String nodes#test_0001_should restrict values to those in the list of allowed values if such a list is provided 0.00 = .0.05 = F                                                                                                                                     

Finished tests in 0.052284s, 38.2527 tests/s, 57.3790 assertions/s.


Failure:
Hermod::XmlSection::String nodes#test_0002_should raise an error if the value is not in the list of allowed values [spec/hermod/xml_section_builder/string_node_spec.rb:76]                                                                     
Minitest::Assertion: --- expected
+++ actual
@@ -1 +1 @@
-"mood must be one of Happy, Sad, or Hangry, not Jubilant"
+"mood must be one of Happy, Sad, or Hangry, not Hangry"


2 tests, 3 assertions, 1 failures, 0 errors, 0 skips
```

## Investigation

A preceding test mutates the `mood` node of the test subject; the flakey spec does not fail if this preceding test does not run.

Further, the `Thread.current.object_id` can be the same, or different, between the two tests. Presumably, minitest makes some decision internally about whether or not to run tests in separate threads. Initial investigation suggests that the test only fails when the tests are run in separate threads.

Note that the running of the tests in separate threads is not a sufficient condition for the test to fail: the test has been seen to pass when different threads are in used. However, it does appear to be a necessary condition.

## Solution

Wrap `Validators::Base#valid?` in a critical section.

The code generation in the XML section builder is such that all instances of a built class share the same underlying validator objects.

The code in `Validators::Base#valid?` is not thread-safe: there is a race between the `test` and `message` steps. This can cause the `value` attribute to have changed in between the call
to `test` and the call to `message`, leading to the wrong message being output (if the message makes use of the value).

This could be fixed by changing `valid?` to pass the `value` and `attributes` to the `test` and `message` methods, rather than storing them as non thread-safe member variables. However, a
quicker fix is simply to wrap `valid?`'s internals in a `Mutex` to coordinate access to this critical section.

## Notes

You can run just this single test as follows.

```sh
bundle exec rake TEST=spec/hermod/xml_section_builder/string_node_spec.rb TESTOPTS="-v"
```