### PR TITLE
Make Validators Thread-Safe

### DIFF
--- a/lib/hermod/validators/allowed_values.rb
+++ b/lib/hermod/validators/allowed_values.rb
@@ -13,11 +13,11 @@ module Hermod
 
       private
 
-      def test
+      def test(value, attributes)
         value.blank? || allowed_values.include?(value)
       end
 
-      def message
+      def message(value, attributes)
         list_of_values = allowed_values.to_sentence(last_word_connector: ", or ", two_words_connector: " or ")
         "must be one of #{list_of_values}, not #{value}"
       end

--- a/lib/hermod/validators/attributes.rb
+++ b/lib/hermod/validators/attributes.rb
@@ -13,16 +13,18 @@ module Hermod
 
       private
 
-      def test
-        @bad_attributes = [] # reset this for each time the validator is used
-        attributes.each do |attribute, _|
-          bad_attributes << attribute unless allowed_attributes.include? attribute
-        end
-        bad_attributes == []
+      def bad_attributes(attributes)
+        attributes.map do |attribute, _|
+          attribute unless allowed_attributes.include? attribute
+        end.compact
       end
 
-      def message
-        "has attributes it doesn't accept: #{bad_attributes.to_sentence}"
+      def test(value, attributes)
+        bad_attributes(attributes) == []
+      end
+
+      def message(value, attributes)
+        "has attributes it doesn't accept: #{bad_attributes(attributes).to_sentence}"
       end
     end
   end

--- a/lib/hermod/validators/base.rb
+++ b/lib/hermod/validators/base.rb
@@ -3,16 +3,13 @@ require 'active_support/core_ext/array/conversions'
 module Hermod
   module Validators
     class Base
-      attr_reader :value, :attributes
-
       # Public: Runs the test for the validator returning true if it passes and
       # raising if it fails
       #
       # Raises a Hermod::InvalidInputError if the test fails
       # Returns true if it succeeds
       def valid?(value, attributes)
-        @value, @attributes = value, attributes
-        !!test || raise(InvalidInputError, message)
+        !!test(value, attributes) || raise(InvalidInputError, message(value, attributes))
       end
 
       private
@@ -21,14 +18,14 @@ module Hermod
       # validator
       #
       # Returns a boolean
-      def test
+      def test(value, attributes)
         raise NotImplementedError
       end
 
       # Private: override in subclasses to provide a more useful error message
       #
       # Returns a string
-      def message
+      def message(value, attributes)
         "is invalid"
       end
     end

--- a/lib/hermod/validators/non_negative.rb
+++ b/lib/hermod/validators/non_negative.rb
@@ -7,11 +7,11 @@ module Hermod
 
       private
 
-      def test
+      def test(value, attributes)
         value.blank? || value >= 0
       end
 
-      def message
+      def message(value, attributes)
         "cannot be negative"
       end
     end

--- a/lib/hermod/validators/non_zero.rb
+++ b/lib/hermod/validators/non_zero.rb
@@ -7,11 +7,11 @@ module Hermod
 
       private
 
-      def test
+      def test(value, attributes)
         value.blank? || value.to_i != 0
       end
 
-      def message
+      def message(value, attributes)
         "cannot be zero"
       end
     end

--- a/lib/hermod/validators/range.rb
+++ b/lib/hermod/validators/range.rb
@@ -16,11 +16,11 @@ module Hermod
 
       private
 
-      def test
+      def test(value, attributes)
         value.blank? || range.cover?(value)
       end
 
-      def message
+      def message(value, attributes)
         "must be between #{range.min} and #{range.max}"
       end
     end

--- a/lib/hermod/validators/regular_expression.rb
+++ b/lib/hermod/validators/regular_expression.rb
@@ -17,11 +17,11 @@ module Hermod
       # because those are checked by the ValuePresence validator if necessary.
       #
       # Returns a boolean
-      def test
+      def test(value, attributes)
         value.blank? || value =~ pattern
       end
 
-      def message
+      def message(value, attributes)
         "#{value.inspect} does not match #{pattern.inspect}"
       end
     end

--- a/lib/hermod/validators/type_checker.rb
+++ b/lib/hermod/validators/type_checker.rb
@@ -23,11 +23,11 @@ module Hermod
 
       private
 
-      def test
+      def test(value, attributes)
         value.blank? || checker.call(value)
       end
 
-      def message
+      def message(value, attributes)
         expected_class_name = expected_class.name.downcase
         join_word = (%w(a e i o u).include?(expected_class_name[0]) ? "an" : "a")
         "must be #{join_word} #{expected_class_name}"

--- a/lib/hermod/validators/value_presence.rb
+++ b/lib/hermod/validators/value_presence.rb
@@ -7,11 +7,11 @@ module Hermod
 
       private
 
-      def test
+      def test(value, attributes)
         value.present?
       end
 
-      def message
+      def message(value, attributes)
         "isn't optional but no value was provided"
       end
     end

--- a/lib/hermod/validators/whole_units.rb
+++ b/lib/hermod/validators/whole_units.rb
@@ -8,11 +8,11 @@ module Hermod
 
       private
 
-      def test
+      def test(value, attributes)
         value.blank? || value == value.to_i
       end
 
-      def message
+      def message(value, attributes)
         "must be in whole units"
       end
     end

--- a/spec/hermod/validators/base_spec.rb
+++ b/spec/hermod/validators/base_spec.rb
@@ -13,7 +13,7 @@ module Hermod
 
       it "has a default error message" do
         class TestValidator < Base
-          def test
+          def test(value, attributes)
             false
           end
         end

--- a/spec/hermod/xml_section_builder/string_node_spec.rb
+++ b/spec/hermod/xml_section_builder/string_node_spec.rb
@@ -72,6 +72,19 @@ module Hermod
         ex.message.must_equal "mood must be one of Happy, Sad, or Hangry, not Jubilant"
       end
 
+      it "should be thread safe for validation" do
+        subject1 = StringXml.new do |string_xml|
+          string_xml.greeting "Hello"
+        end
+
+        Thread.new do
+          subject1.mood "Hangry"
+        end
+
+        ex = proc { subject.mood "Jubilant" }.must_raise InvalidInputError
+        ex.message.must_equal "mood must be one of Happy, Sad, or Hangry, not Jubilant"
+      end
+
       it "should use the given keys for attributes" do
         subject.title "Sir", masculine: "no"
         attributes_for_node("Title").keys.first.must_equal "Male"


### PR DESCRIPTION
## Synopsis

We are seeing a flakey spec failure:

```
Hermod::XmlSection::String nodes#test_0002_should raise an error if the value is not in the list of allowed values 
Hermod::XmlSection::String nodes#test_0001_should restrict values to those in the list of allowed values if such a list is provided 0.00 = .0.05 = F                                                                                                                                     

Finished tests in 0.052284s, 38.2527 tests/s, 57.3790 assertions/s.


Failure:
Hermod::XmlSection::String nodes#test_0002_should raise an error if the value is not in the list of allowed values [spec/hermod/xml_section_builder/string_node_spec.rb:76]                                                                     
Minitest::Assertion: --- expected
+++ actual
@@ -1 +1 @@
-"mood must be one of Happy, Sad, or Hangry, not Jubilant"
+"mood must be one of Happy, Sad, or Hangry, not Hangry"


2 tests, 3 assertions, 1 failures, 0 errors, 0 skips
```

## Investigation

A preceding test mutates the `mood` node of the test subject; the flakey spec does not fail if this preceding test does not run.

Further, the `Thread.current.object_id` can be the same, or different, between the two tests. Presumably, minitest makes some decision internally about whether or not to run tests in separate threads. Initial investigation suggests that the test only fails when the tests are run in separate threads.

Note that the running of the tests in separate threads is not a sufficient condition for the test to fail: the test has been seen to pass when different threads are in used. However, it does appear to be a necessary condition.

## Solution

Since each instance of a class shares its validators, it does not make sense for the validators to maintain state between testing and producing their error message.  So we have moved the `@value` and `@attributes` variables into parameters to the `test` and `message` methods.

## Notes

You can run just this single test as follows.

```sh
bundle exec rake TEST=spec/hermod/xml_section_builder/string_node_spec.rb TESTOPTS="-v"
```