### PR TITLE
Upgrade rake dev dependency to latest version

### DIFF
--- a/hermod.gemspec
+++ b/hermod.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activesupport", "> 3.2", "< 7"
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 11.1"
+  spec.add_development_dependency "rake", "13.0.1"
   spec.add_development_dependency "minitest", "~> 5.3"
   spec.add_development_dependency "minitest-reporters", "~> 1.0", ">= 1.0.16"
   spec.add_development_dependency "nokogiri", "~> 1.5"


### PR DESCRIPTION
This is a gem dev dependency, hence the specific versioning.

No changelog or version increase required since there's no change to public API.

Will close #33 