### PR TITLE
Fix issue with missing require in later active_support releases

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -5,9 +5,9 @@ jobs:
     name: runner / actionlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: actionlint
-        uses: reviewdog/action-actionlint@v1.2.0
+        uses: reviewdog/action-actionlint@v1
         with:
           fail_on_error: true
           reporter: github-pr-review

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Remove unused bad_attributes attr_reader on `Hermod::Validators::Attributes`
 
+### Changed
+- Updated development dependencies
+
 ## [2.6.2] - 2022-01-10
 ### Changed
 - Remove the upper limit on the activesupport version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Added missing require in `Hermod::XmlSectionBuilder`
+- Fixed deprecations in Minitest
 
 ### Removed
 - Remove unused bad_attributes attr_reader on `Hermod::Validators::Attributes`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Added missing require in `Hermod::XmlSectionBuilder`
+
 ### Removed
 - Remove unused bad_attributes attr_reader on `Hermod::Validators::Attributes`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Remove unused bad_attributes attr_reader on `Hermod::Validators::Attributes`
 
-##[2.6.2] - 2022-01-10
+## [2.6.2] - 2022-01-10
+### Changed
 - Remove the upper limit on the activesupport version
 
-##[2.6.1] - 2020-10-22
+## [2.6.1] - 2020-10-22
 ## Added
 - Changelog updates
 
-##[2.6.0] - 2020-10-22
+## [2.6.0] - 2020-10-22
 ## Added
 - Update libxml-ruby to version ~> 3.2
 - Update ruby-version to 2.7.1
 
-##[2.5.3] - 2019-11-01
+## [2.5.3] - 2019-11-01
 ### Added
 - Link wiki to the readme file.
 

--- a/hermod.gemspec
+++ b/hermod.gemspec
@@ -27,9 +27,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "13.0.1"
-  spec.add_development_dependency "minitest", "~> 5.3"
-  spec.add_development_dependency "minitest-reporters", "~> 1.0", ">= 1.0.16"
-  spec.add_development_dependency "nokogiri", "~> 1.5"
+  spec.add_development_dependency "minitest", "~> 5.15"
+  spec.add_development_dependency "minitest-reporters", ">= 1.0.16", "~> 1.5"
+  spec.add_development_dependency "nokogiri", "~> 1.13"
 
   spec.metadata = {
     "allowed_push_host" => "https://rubygems.org",

--- a/lib/hermod/validators/attributes.rb
+++ b/lib/hermod/validators/attributes.rb
@@ -4,7 +4,7 @@ module Hermod
   module Validators
     # Checks the attributes are in a list of allowed attributes
     class Attributes < Base
-      attr_reader :allowed_attributes, :bad_attributes
+      attr_reader :allowed_attributes
 
       # Public: Sets up the list of allowed attributes
       def initialize(allowed_attributes)

--- a/lib/hermod/version.rb
+++ b/lib/hermod/version.rb
@@ -1,3 +1,3 @@
 module Hermod
-  VERSION = "2.6.2"
+  VERSION = "2.7.0-rc.1"
 end

--- a/lib/hermod/xml_section_builder.rb
+++ b/lib/hermod/xml_section_builder.rb
@@ -1,7 +1,8 @@
-require 'bigdecimal'
 require 'active_support'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/object/blank'
+require 'bigdecimal'
+require 'date'
 
 require 'hermod/xml_node'
 require 'hermod/input_mutator'

--- a/spec/hermod/validators/allowed_values_spec.rb
+++ b/spec/hermod/validators/allowed_values_spec.rb
@@ -8,17 +8,17 @@ module Hermod
       end
 
       it "permits values in the list" do
-        subject.valid?("Cat", {}).must_equal true
+        expect(subject.valid?("Cat", {})).must_equal true
       end
 
       it "allows blank values" do
-        subject.valid?("", {}).must_equal true
-        subject.valid?(nil, {}).must_equal true
+        expect(subject.valid?("", {})).must_equal true
+        expect(subject.valid?(nil, {})).must_equal true
       end
 
       it "raises an error for values not in the list" do
-        ex = proc { subject.valid?("Albatross", {}) }.must_raise InvalidInputError
-        ex.message.must_equal "must be one of Antelope, Bear, Cat, Dog, or Elephant, not Albatross"
+        ex = expect { subject.valid?("Albatross", {}) }.must_raise InvalidInputError
+        expect(ex.message).must_equal "must be one of Antelope, Bear, Cat, Dog, or Elephant, not Albatross"
       end
     end
   end

--- a/spec/hermod/validators/attributes_spec.rb
+++ b/spec/hermod/validators/attributes_spec.rb
@@ -8,12 +8,12 @@ module Hermod
       end
 
       it "permits attributes in the list" do
-        subject.valid?(nil, {species: "Felis catus", genus: "Felis"}).must_equal true
+        expect(subject.valid?(nil, {species: "Felis catus", genus: "Felis"})).must_equal true
       end
 
       it "raises an error for attributes not in the list" do
-        ex = proc { subject.valid?(nil, {phylum: "Chordata"}) }.must_raise InvalidInputError
-        ex.message.must_equal "has attributes it doesn't accept: phylum"
+        ex = expect { subject.valid?(nil, {phylum: "Chordata"}) }.must_raise InvalidInputError
+        expect(ex.message).must_equal "has attributes it doesn't accept: phylum"
       end
     end
   end

--- a/spec/hermod/validators/base_spec.rb
+++ b/spec/hermod/validators/base_spec.rb
@@ -8,7 +8,7 @@ module Hermod
       end
 
       it "doesn't implement a test" do
-        proc { subject.valid?(nil, {}) }.must_raise NotImplementedError
+        expect { subject.valid?(nil, {}) }.must_raise NotImplementedError
       end
 
       it "has a default error message" do
@@ -17,8 +17,8 @@ module Hermod
             false
           end
         end
-        ex = proc { TestValidator.new.valid?(nil, {}) }.must_raise InvalidInputError
-        ex.message.must_equal "is invalid"
+        ex = expect { TestValidator.new.valid?(nil, {}) }.must_raise InvalidInputError
+        expect(ex.message).must_equal "is invalid"
       end
     end
   end

--- a/spec/hermod/validators/non_negative_spec.rb
+++ b/spec/hermod/validators/non_negative_spec.rb
@@ -8,20 +8,20 @@ module Hermod
       end
 
       it "allows positive values" do
-        subject.valid?(1, {}).must_equal true
+        expect(subject.valid?(1, {})).must_equal true
       end
 
       it "allows zero values" do
-        subject.valid?(0, {}).must_equal true
+        expect(subject.valid?(0, {})).must_equal true
       end
 
       it "allows blank values" do
-        subject.valid?(nil, {}).must_equal true
+        expect(subject.valid?(nil, {})).must_equal true
       end
 
       it "raises an error for negative values" do
-        ex = proc { subject.valid?(-1, {}) }.must_raise InvalidInputError
-        ex.message.must_equal "cannot be negative"
+        ex = expect { subject.valid?(-1, {}) }.must_raise InvalidInputError
+        expect(ex.message).must_equal "cannot be negative"
       end
     end
   end

--- a/spec/hermod/validators/non_zero_spec.rb
+++ b/spec/hermod/validators/non_zero_spec.rb
@@ -8,20 +8,20 @@ module Hermod
       end
 
       it "allows positive values" do
-        subject.valid?(1, {}).must_equal true
+        expect(subject.valid?(1, {})).must_equal true
       end
 
       it "allows negative values" do
-        subject.valid?(-1, {}).must_equal true
+        expect(subject.valid?(-1, {})).must_equal true
       end
 
       it "allows blank values" do
-        subject.valid?(nil, {}).must_equal true
+        expect(subject.valid?(nil, {})).must_equal true
       end
 
       it "raises an error for zero values" do
-        ex = proc { subject.valid?(0, {}) }.must_raise InvalidInputError
-        ex.message.must_equal "cannot be zero"
+        ex = expect { subject.valid?(0, {}) }.must_raise InvalidInputError
+        expect(ex.message).must_equal "cannot be zero"
       end
     end
   end

--- a/spec/hermod/validators/range_spec.rb
+++ b/spec/hermod/validators/range_spec.rb
@@ -8,21 +8,21 @@ module Hermod
       end
 
       it "allows values in the range" do
-        subject.valid?(1, {}).must_equal true
-        subject.valid?(7, {}).must_equal true
+        expect(subject.valid?(1, {})).must_equal true
+        expect(subject.valid?(7, {})).must_equal true
       end
 
       it "allows blank values" do
-        subject.valid?(nil, {}).must_equal true
+        expect(subject.valid?(nil, {})).must_equal true
       end
 
       it "raises an error for values outwith the range" do
-        ex = proc { subject.valid?(0, {}) }.must_raise InvalidInputError
-        ex.message.must_equal "must be between 1 and 7"
+        ex = expect { subject.valid?(0, {}) }.must_raise InvalidInputError
+        expect(ex.message).must_equal "must be between 1 and 7"
       end
 
       it "can also take a min and max as arguments" do
-        Range.new(1, 7).valid?(3, {}).must_equal true
+        expect(Range.new(1, 7).valid?(3, {})).must_equal true
       end
     end
   end

--- a/spec/hermod/validators/regular_expression_spec.rb
+++ b/spec/hermod/validators/regular_expression_spec.rb
@@ -8,17 +8,17 @@ module Hermod
       end
 
       it "allows values that match the pattern" do
-        subject.valid?("AB123456C", {}).must_equal true
+        expect(subject.valid?("AB123456C", {})).must_equal true
       end
 
       it "allows blank values" do
-        subject.valid?("", {}).must_equal true
-        subject.valid?(nil, {}).must_equal true
+        expect(subject.valid?("", {})).must_equal true
+        expect(subject.valid?(nil, {})).must_equal true
       end
 
       it "raises an error for values that don't match the pattern" do
-        ex = proc { subject.valid?("fish", {}) }.must_raise InvalidInputError
-        ex.message.must_equal "\"fish\" does not match /\\A[A-Z]{2} [0-9]{6} [A-D]\\z/x"
+        ex = expect { subject.valid?("fish", {}) }.must_raise InvalidInputError
+        expect(ex.message).must_equal "\"fish\" does not match /\\A[A-Z]{2} [0-9]{6} [A-D]\\z/x"
       end
     end
   end

--- a/spec/hermod/validators/type_checker_spec.rb
+++ b/spec/hermod/validators/type_checker_spec.rb
@@ -5,27 +5,27 @@ module Hermod
     describe TypeChecker do
       it "uses a default block that checks the value is an instance of the given class" do
         checker = TypeChecker.new(Integer)
-        checker.valid?(1, {}).must_equal true
-        proc { checker.valid?(1.0, {}) }.must_raise InvalidInputError
+        expect(checker.valid?(1, {})).must_equal true
+        expect { checker.valid?(1.0, {}) }.must_raise InvalidInputError
       end
 
       it "allows you to give a block to be more discerning" do
         checker = TypeChecker.new(Integer) { |val| val > 0 }
-        checker.valid?(5, {}).must_equal true
-        proc { checker.valid?(-2, {}) }.must_raise InvalidInputError
+        expect(checker.valid?(5, {})).must_equal true
+        expect { checker.valid?(-2, {}) }.must_raise InvalidInputError
       end
 
       it "ignores blank values" do
         checker = TypeChecker.new(Integer)
-        checker.valid?(nil, {}).must_equal true
+        expect(checker.valid?(nil, {})).must_equal true
       end
 
       it "gives the correct message" do
-        ex = proc { TypeChecker.new(Integer).valid?(1.0, {}) }.must_raise InvalidInputError
-        ex.message.must_equal "must be an integer"
+        ex = expect { TypeChecker.new(Integer).valid?(1.0, {}) }.must_raise InvalidInputError
+        expect(ex.message).must_equal "must be an integer"
 
-        ex = proc { TypeChecker.new(Float).valid?(1, {}) }.must_raise InvalidInputError
-        ex.message.must_equal "must be a float"
+        ex = expect { TypeChecker.new(Float).valid?(1, {}) }.must_raise InvalidInputError
+        expect(ex.message).must_equal "must be a float"
       end
     end
   end

--- a/spec/hermod/validators/value_presence_spec.rb
+++ b/spec/hermod/validators/value_presence_spec.rb
@@ -8,12 +8,12 @@ module Hermod
       end
 
       it "allows values that are present" do
-        subject.valid?(1, {}).must_equal true
+        expect(subject.valid?(1, {})).must_equal true
       end
 
       it "raises an error for missing values" do
-        ex = proc { subject.valid?(nil, {}) }.must_raise InvalidInputError
-        ex.message.must_equal "isn't optional but no value was provided"
+        ex = expect { subject.valid?(nil, {}) }.must_raise InvalidInputError
+        expect(ex.message).must_equal "isn't optional but no value was provided"
       end
     end
   end

--- a/spec/hermod/validators/whole_units_spec.rb
+++ b/spec/hermod/validators/whole_units_spec.rb
@@ -8,16 +8,16 @@ module Hermod
       end
 
       it "allows values that are in whole units" do
-        subject.valid?(1.0, {}).must_equal true
+        expect(subject.valid?(1.0, {})).must_equal true
       end
 
       it "allows blank values" do
-        subject.valid?(nil, {}).must_equal true
+        expect(subject.valid?(nil, {})).must_equal true
       end
 
       it "raises an error for values with a fractional componant" do
-        ex = proc { subject.valid?(3.1415, {}) }.must_raise InvalidInputError
-        ex.message.must_equal "must be in whole units"
+        ex = expect { subject.valid?(3.1415, {}) }.must_raise InvalidInputError
+        expect(ex.message).must_equal "must be in whole units"
       end
     end
   end

--- a/spec/hermod/xml_section_builder/date_node_spec.rb
+++ b/spec/hermod/xml_section_builder/date_node_spec.rb
@@ -16,16 +16,16 @@ module Hermod
       end
 
       it "should format the date with the given date string" do
-        value_of_node("DateOfBirth").must_equal "1988-08-13"
+        expect(value_of_node("DateOfBirth")).must_equal "1988-08-13"
       end
 
       it "should raise an error if given something that isn't a date" do
-        proc { subject.anniversary "yesterday" }.must_raise InvalidInputError
+        expect { subject.anniversary "yesterday" }.must_raise InvalidInputError
       end
 
       it "should ignore blank dates if the date is optional" do
         subject.anniversary nil
-        nodes("Anniversary").must_be_empty
+        expect(nodes("Anniversary")).must_be_empty
       end
     end
   end

--- a/spec/hermod/xml_section_builder/datetime_node_spec.rb
+++ b/spec/hermod/xml_section_builder/datetime_node_spec.rb
@@ -16,16 +16,16 @@ module Hermod
       end
 
       it "should format the datetime with the given format string" do
-        value_of_node("Published").must_equal "2015-03-14 12:30:56"
+        expect(value_of_node("Published")).must_equal "2015-03-14 12:30:56"
       end
 
       it "should raise an error if given something that isn't a date" do
-        proc { subject.redacted "yesterday" }.must_raise InvalidInputError
+        expect { subject.redacted "yesterday" }.must_raise InvalidInputError
       end
 
       it "should ignore blank dates if the date is optional" do
         subject.redacted nil
-        nodes("Redacted").must_be_empty
+        expect(nodes("Redacted")).must_be_empty
       end
     end
   end

--- a/spec/hermod/xml_section_builder/integer_node_spec.rb
+++ b/spec/hermod/xml_section_builder/integer_node_spec.rb
@@ -14,15 +14,15 @@ module Hermod
 
       it "should accept a valid number" do
         subject.day_of_the_week 7
-        value_of_node("DayOfTheWeek").must_equal "7"
+        expect(value_of_node("DayOfTheWeek")).must_equal "7"
       end
 
       it "should raise an error if the number is above the maximum" do
-        proc { subject.day_of_the_week 8 }.must_raise InvalidInputError
+        expect { subject.day_of_the_week 8 }.must_raise InvalidInputError
       end
 
       it "should raise an error if the number is below the minimum" do
-        proc { subject.day_of_the_week 0 }.must_raise InvalidInputError
+        expect { subject.day_of_the_week 0 }.must_raise InvalidInputError
       end
     end
   end

--- a/spec/hermod/xml_section_builder/monetary_node_spec.rb
+++ b/spec/hermod/xml_section_builder/monetary_node_spec.rb
@@ -20,44 +20,44 @@ module Hermod
       end
 
       it "should format values with the provided format string" do
-        value_of_node("Pay").must_equal "123.45"
+        expect(value_of_node("Pay")).must_equal "123.45"
       end
 
       it "should not include optional nodes if they're zero" do
-        number_of_nodes("Tax").must_equal 0
+        expect(number_of_nodes("Tax")).must_equal 0
       end
 
       it "should use xml_name as the node name if provided" do
         subject.ni 100
-        number_of_nodes("NI").must_equal 1
+        expect(number_of_nodes("NI")).must_equal 1
       end
 
       it "should raise an error if given a negative number for a field that cannot be negative" do
-        ex = proc { subject.ni -100 }.must_raise InvalidInputError
-        ex.message.must_equal "ni cannot be negative"
+        ex = expect { subject.ni(-100) }.must_raise InvalidInputError
+        expect(ex.message).must_equal "ni cannot be negative"
       end
 
       it "should allow negative numbers for fields by default" do
         subject.pension(-100)
-        value_of_node("Pension").must_equal "-100.00"
+        expect(value_of_node("Pension")).must_equal "-100.00"
       end
 
       it "should not allow decimal values for whole unit nodes" do
-        ex = proc { subject.pension BigDecimal("12.34") }.must_raise InvalidInputError
-        ex.message.must_equal "pension must be in whole units"
+        ex = expect { subject.pension BigDecimal("12.34") }.must_raise InvalidInputError
+        expect(ex.message).must_equal "pension must be in whole units"
       end
 
       it "should not allow zero for nodes that disallow it" do
-        ex = proc { subject.student_loan 0 }.must_raise Hermod::InvalidInputError
-        ex.message.must_equal "student_loan cannot be zero"
+        ex = expect { subject.student_loan 0 }.must_raise Hermod::InvalidInputError
+        expect(ex.message).must_equal "student_loan cannot be zero"
       end
 
       it "should treat blank nodes as zero nodes" do
         subject.ni nil
-        value_of_node("NI").must_equal "0.00"
+        expect(value_of_node("NI")).must_equal "0.00"
 
         subject.tax nil
-        nodes("Tax").must_be_empty
+        expect(nodes("Tax")).must_be_empty
       end
     end
   end

--- a/spec/hermod/xml_section_builder/parent_node_spec.rb
+++ b/spec/hermod/xml_section_builder/parent_node_spec.rb
@@ -21,7 +21,7 @@ module Hermod
 
       it "should correctly wrap the inner XML" do
         expected = "<ParentXml>\n  <InnerXml>\n    <Inside>layered like an onion</Inside>\n  </InnerXml>\n</ParentXml>"
-        subject.to_xml.to_s.must_equal expected
+        expect(subject.to_xml.to_s).must_equal expected
       end
     end
   end

--- a/spec/hermod/xml_section_builder/string_node_spec.rb
+++ b/spec/hermod/xml_section_builder/string_node_spec.rb
@@ -33,43 +33,43 @@ module Hermod
       end
 
       it "should set node contents correctly" do
-        value_of_node("Greeting").must_equal "Hello"
+        expect(value_of_node("Greeting")).must_equal "Hello"
       end
 
       it "should allow values that pass the regex validation" do
         subject.title "Sir"
-        value_of_node("Title").must_equal "Sir"
+        expect(value_of_node("Title")).must_equal "Sir"
       end
 
       it "should raise an error when the regex validation fails" do
-        ex = proc { subject.title "Laird" }.must_raise InvalidInputError
-        ex.message.must_equal %(title "Laird" does not match /\\ASir|Dame\\z/)
+        ex = expect { subject.title "Laird" }.must_raise InvalidInputError
+        expect(ex.message).must_equal %(title "Laird" does not match /\\ASir|Dame\\z/)
       end
 
       it "should require all non-optional nodes to have content" do
-        ex = proc { subject.required "" }.must_raise InvalidInputError
-        ex.message.must_equal "required isn't optional but no value was provided"
+        ex = expect { subject.required "" }.must_raise InvalidInputError
+        expect(ex.message).must_equal "required isn't optional but no value was provided"
       end
 
       it "should apply changes to the inputs if a input_mutator is provided" do
         subject.gender "Male"
-        value_of_node("Gender").must_equal "M"
+        expect(value_of_node("Gender")).must_equal "M"
       end
 
       it "should allow input_mutators to access nodes the instance" do
         subject.mood "Hangry"
         subject.status "Eating cookies"
-        value_of_node("Status").must_equal "Eating cookies furiously"
+        expect(value_of_node("Status")).must_equal "Eating cookies furiously"
       end
 
       it "should restrict values to those in the list of allowed values if such a list is provided" do
         subject.mood "Hangry"
-        value_of_node("Mood").must_equal "Hangry"
+        expect(value_of_node("Mood")).must_equal "Hangry"
       end
 
       it "should raise an error if the value is not in the list of allowed values" do
-        ex = proc { subject.mood "Jubilant" }.must_raise InvalidInputError
-        ex.message.must_equal "mood must be one of Happy, Sad, or Hangry, not Jubilant"
+        ex = expect { subject.mood "Jubilant" }.must_raise InvalidInputError
+        expect(ex.message).must_equal "mood must be one of Happy, Sad, or Hangry, not Jubilant"
       end
 
       it "should be thread safe for validation" do
@@ -81,23 +81,23 @@ module Hermod
           subject1.mood "Hangry"
         end
 
-        ex = proc { subject.mood "Jubilant" }.must_raise InvalidInputError
-        ex.message.must_equal "mood must be one of Happy, Sad, or Hangry, not Jubilant"
+        ex = expect { subject.mood "Jubilant" }.must_raise InvalidInputError
+        expect(ex.message).must_equal "mood must be one of Happy, Sad, or Hangry, not Jubilant"
       end
 
       it "should use the given keys for attributes" do
         subject.title "Sir", masculine: "no"
-        attributes_for_node("Title").keys.first.must_equal "Male"
-        attributes_for_node("Title")["Male"].value.must_equal "no"
+        expect(attributes_for_node("Title").keys.first).must_equal "Male"
+        expect(attributes_for_node("Title")["Male"].value).must_equal "no"
       end
 
       it "should raise an error if given an attribute that isn't expected" do
-        proc { subject.title "Sir", knight: "yes" }.must_raise InvalidInputError
+        expect { subject.title "Sir", knight: "yes" }.must_raise InvalidInputError
       end
 
       it "should not include empty, optional nodes" do
         subject.name ""
-        nodes("Name").must_be_empty
+        expect(nodes("Name")).must_be_empty
       end
     end
   end

--- a/spec/hermod/xml_section_builder/yes_no_node_spec.rb
+++ b/spec/hermod/xml_section_builder/yes_no_node_spec.rb
@@ -16,7 +16,7 @@ module Hermod
         end
 
         it "should include the node with yes as the contents" do
-          value_of_node("Awesome").must_equal "yes"
+          expect(value_of_node("Awesome")).must_equal "yes"
         end
       end
 
@@ -28,7 +28,7 @@ module Hermod
         end
 
         it "should include the node with no as the contents" do
-          value_of_node("Awesome").must_equal "no"
+          expect(value_of_node("Awesome")).must_equal "no"
         end
       end
     end

--- a/spec/hermod/xml_section_builder/yes_node_spec.rb
+++ b/spec/hermod/xml_section_builder/yes_node_spec.rb
@@ -16,7 +16,7 @@ module Hermod
         end
 
         it "should include the node with yes as the contents" do
-          value_of_node("Awesome").must_equal "yes"
+          expect(value_of_node("Awesome")).must_equal "yes"
         end
       end
 
@@ -28,7 +28,7 @@ module Hermod
         end
 
         it "should not include the node" do
-          number_of_nodes("Awesome").must_equal 0
+          expect(number_of_nodes("Awesome")).must_equal 0
         end
       end
     end

--- a/spec/hermod/xml_section_spec.rb
+++ b/spec/hermod/xml_section_spec.rb
@@ -21,7 +21,7 @@ module Hermod
       end
 
       it "should use the class name as the XML node name" do
-        subject.to_xml.name.must_equal "UnnamedXML"
+        expect(subject.to_xml.name).must_equal "UnnamedXML"
       end
     end
 
@@ -31,7 +31,7 @@ module Hermod
       end
 
       it "should use the class name as the XML node name" do
-        subject.to_xml.name.must_equal "Testing"
+        expect(subject.to_xml.name).must_equal "Testing"
       end
     end
 
@@ -44,11 +44,11 @@ module Hermod
       end
 
       it "formats dates in yyyy-mm-dd form" do
-        value_of_node("Birthday").must_equal("1988-08-13")
+        expect(value_of_node("Birthday")).must_equal("1988-08-13")
       end
 
       it "formats money to two decimal places" do
-        value_of_node("Allowance").must_equal("20.00")
+        expect(value_of_node("Allowance")).must_equal("20.00")
       end
     end
 
@@ -63,32 +63,32 @@ module Hermod
       end
 
       it "should order nodes by the order they were defined when the class was built" do
-        node_by_index(0).name.must_equal "First"
-        node_by_index(0).content.must_equal "alpha"
+        expect(node_by_index(0).name).must_equal "First"
+        expect(node_by_index(0).content).must_equal "alpha"
 
-        node_by_index(1).name.must_equal "Repeated"
-        node_by_index(1).content.must_equal "beta"
+        expect(node_by_index(1).name).must_equal "Repeated"
+        expect(node_by_index(1).content).must_equal "beta"
 
-        node_by_index(-1).name.must_equal "Last"
-        node_by_index(-1).content.must_equal "epsilon"
+        expect(node_by_index(-1).name).must_equal "Last"
+        expect(node_by_index(-1).content).must_equal "epsilon"
       end
 
       it "should order nodes called multiple times in the order they were called" do
-        node_by_index(1).name.must_equal "Repeated"
-        node_by_index(1).content.must_equal "beta"
+        expect(node_by_index(1).name).must_equal "Repeated"
+        expect(node_by_index(1).content).must_equal "beta"
 
-        node_by_index(2).name.must_equal "Repeated"
-        node_by_index(2).content.must_equal "gamma"
+        expect(node_by_index(2).name).must_equal "Repeated"
+        expect(node_by_index(2).content).must_equal "gamma"
       end
 
       it "should order nodes at XML generation time, not at call time" do
         subject.repeated "delta"
 
-        node_by_index(-2).name.must_equal "Repeated"
-        node_by_index(-2).content.must_equal "delta"
+        expect(node_by_index(-2).name).must_equal "Repeated"
+        expect(node_by_index(-2).content).must_equal "delta"
 
-        node_by_index(-1).name.must_equal "Last"
-        node_by_index(-1).content.must_equal "epsilon"
+        expect(node_by_index(-1).name).must_equal "Last"
+        expect(node_by_index(-1).content).must_equal "epsilon"
       end
     end
   end

--- a/spec/hermod_spec.rb
+++ b/spec/hermod_spec.rb
@@ -2,6 +2,6 @@ require 'minitest_helper'
 
 describe Hermod do
   it "should have a version number" do
-    Hermod::VERSION.wont_be_nil
+    expect(Hermod::VERSION).wont_be_nil
   end
 end


### PR DESCRIPTION
Including apps started failing in some cases with a missing `require "date"`.

This release also fixes warnings and deprecations when running the minitest suite:

- Shadowed `bad_attributes` method
- Moving to using `#expect` monads instead of using the money-patched `Object` methods, which will be removed in Minitest 6.