### PR TITLE
Adding SonarCloud badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=fac_hermod&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=fac_hermod)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=fac_hermod&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=fac_hermod)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=fac_hermod&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=fac_hermod)
+
 # Hermod
 
 [![Gem](https://github.com/fac/hermod/actions/workflows/freeagent-gem.yml/badge.svg)](https://github.com/fac/hermod/actions/workflows/freeagent-gem.yml)


### PR DESCRIPTION
 # What
Adding SonarCloud badges to the repo README

Dev-P ticket
 - https://github.com/fac/dev-platform/issues/1764