### PR TITLE
Bump minimum ruby version for dependabot

### DIFF
--- a/hermod.gemspec
+++ b/hermod.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 3.0"
 
   spec.add_runtime_dependency "libxml-ruby", "~> 4.1"
   spec.add_runtime_dependency "activesupport", "> 3.2"


### PR DESCRIPTION
I believe dependabot will use the oldest ruby version specified. However nokogiri needs atleast version 3.0. Make this the minimum version