### PR TITLE
Update libxml-ruby and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2025-01-03
+### Changed
+- Bumped minimum ruby requirement from 2.5 to 3.0
+- Updated nokogiri, rake, libxml-ruby, guard, prydoc, pry-byebug versions
+
 ## [3.0.0] - 2023-04-19
 ### Removed
 - Removed support for Ruby 2.0 - 2.4, minimum supported version is now 2.5

--- a/hermod.gemspec
+++ b/hermod.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.0"
 
-  spec.add_runtime_dependency "libxml-ruby", "~> 4.1"
+  spec.add_runtime_dependency "libxml-ruby", "~> 5.0.3"
   spec.add_runtime_dependency "activesupport", "> 3.2"
 
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/lib/hermod/version.rb
+++ b/lib/hermod/version.rb
@@ -1,3 +1,3 @@
 module Hermod
-  VERSION = "3.0.0"
+  VERSION = "3.1.0"
 end


### PR DESCRIPTION
Uses the latest libxml-ruby version and bumps the version of the gem to 3.1.0. Changelog also updated with changes since the last published version.