### PR TITLE
Bump minimum ruby version to 3.1

### DIFF
--- a/hermod.gemspec
+++ b/hermod.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.add_runtime_dependency "libxml-ruby", "~> 5.0.3"
   spec.add_runtime_dependency "activesupport", "> 3.2"


### PR DESCRIPTION
Dependabot uses ruby v3.0 to bundle, however nokogiri requires ruby v3.1, resulting in dependabot to fail

```
Dependabot can't resolve your Ruby dependency files
Dependabot failed to update your dependencies because there was an error resolving your Ruby dependency files.

Dependabot encountered the following error:

Could not find compatible versions

Because nokogiri >= 1.18.3 depends on Ruby >= 3.1.0, < 3.5.dev
  and nokogiri = 1.18.3 depends on Ruby >= 3.1.0,
  nokogiri >= 1.18.3 requires Ruby >= 3.1.0.
So, because Gemfile depends on nokogiri = 1.18.3
  and current Ruby version is = 3.0.6,
  version solving has failed.
```