### PR TITLE
Add support for pre-releases

### DIFF
--- a/.github/workflows/freeagent-gem.yml
+++ b/.github/workflows/freeagent-gem.yml
@@ -2,10 +2,8 @@ name: Release Gem
 
 on:
   push:
-    branches:
-      - master
     paths:
-      - "lib/hermod/version.rb"
+      - 'lib/hermod/version.rb'
 
 jobs:
   release:
@@ -24,4 +22,14 @@ jobs:
       - name: Test
         run: bundle exec rake
 
-      - uses: rubygems/release-gem@v1
+      - name: Check for pre-release
+        id: is_prerelease
+        run: echo "is_prerelease=$(ruby -e 'puts Gem::Specification.load("hermod.gemspec").version.prerelease?')" >> "$GITHUB_OUTPUT"
+
+      - name: Create a Pre-release
+        if: ${{ github.ref != 'refs/heads/master' && steps.is_prerelease.outputs.is_prerelease == 'true' }}
+        uses: rubygems/release-gem@v1
+
+      - name: Create a Release
+        if: ${{ github.ref == 'refs/heads/master' && steps.is_prerelease.outputs.is_prerelease == 'false' }}
+        uses: rubygems/release-gem@v1


### PR DESCRIPTION
Nikolas is interested in supporting pre-releases:
- [Slack Thread](https://freeagent.slack.com/archives/C0YCN9R5Y/p1779199637271789)

The intended workflow here is:
- Create a branch with changes
- Bump `version.rb` to a pre-release version
- Push to GitHub

The workflow will:
- runs the tests
- checks if version is a pre-release
- triggers a pre-release (only supported on non-master branches)
- trigger a release (only supported on master)